### PR TITLE
17 blog post images

### DIFF
--- a/app/blog/category/[category]/page.tsx
+++ b/app/blog/category/[category]/page.tsx
@@ -2,6 +2,7 @@ import { getPostsByCategory } from "../../../../lib/utils";
 import BlogCard from "../../../../components/BlogCard/BlogCard";
 import styles from "./page.module.css";
 
+
 export default async function CategoryPage({
   params,
 }: {

--- a/app/blog/post/[slug]/page.tsx
+++ b/app/blog/post/[slug]/page.tsx
@@ -17,7 +17,7 @@ export default async function BlogPost({
   }
 
   return (
-    <BlogLayout>
+    <BlogLayout post={post}>
       <ReactMarkdown
         components={{
           a: ({ href, children }) => <Link href={href || "#"}>{children}</Link>,

--- a/components/BlogCard/BlogCard.tsx
+++ b/components/BlogCard/BlogCard.tsx
@@ -5,7 +5,6 @@ import { BlogPostProps } from "../../lib/types";
 import Image from "next/image";
 
 const BlogCard = ({ post }: { post: BlogPostProps }) => {
-  console.log("Image URL:", post.thumbnail);
   return (
     <ul className={styles.container}>
       <li>

--- a/components/BlogCard/BlogCard.tsx
+++ b/components/BlogCard/BlogCard.tsx
@@ -10,7 +10,7 @@ const BlogCard = ({ post }: { post: BlogPostProps }) => {
     <ul className={styles.container}>
       <li>
         <div className={styles.imageWrapper}>
-          <Link href={{ pathname: "blog/" + post.slug }}>
+          <Link href={{ pathname: "blog/post/" + post.slug }}>
             <Image
               src={post.thumbnail}
               alt={post.title + " image"}
@@ -26,7 +26,7 @@ const BlogCard = ({ post }: { post: BlogPostProps }) => {
           <li>
             <Link
               className={styles.title}
-              href={{ pathname: "blog/" + post.slug }}
+              href={{ pathname: "blog/post/" + post.slug }}
             >
               {post.title}
             </Link>

--- a/components/BlogLayout/BlogLayout.tsx
+++ b/components/BlogLayout/BlogLayout.tsx
@@ -1,7 +1,27 @@
 import React, { ReactNode } from "react";
+import { BlogPostProps } from "../../lib/types";
+import Image from "next/image";
 
-const BlogLayout = ({ children }: { children: ReactNode }) => {
-  return <div className="blog-layout">{children}</div>;
+const BlogLayout = ({
+  post,
+  children,
+}: {
+  post: BlogPostProps;
+  children: ReactNode;
+}) => {
+  return (
+    <div className="blog-layout">
+      {post.thumbnail && post.thumbnail.trim() !== "" && (
+        <Image
+          src={post.thumbnail}
+          alt={post.title + " image"}
+          width={400}
+          height={300}
+        ></Image>
+      )}
+      {children}
+    </div>
+  );
 };
 
 export default BlogLayout;


### PR DESCRIPTION
closes #17 

Images are now included in blog posts instead of just the home page.

<img width="1444" alt="Screenshot 2025-05-01 at 10 34 49 am" src="https://github.com/user-attachments/assets/d2866475-c079-4330-bd8f-e51b33538908" />
